### PR TITLE
Fix typo in permission error message in word companion

### DIFF
--- a/XcodePlugin/BookmarkedURL.swift
+++ b/XcodePlugin/BookmarkedURL.swift
@@ -16,7 +16,7 @@ enum BookmarkedURL {
             return bookmarkedURL
         }
         throw error(
-            "The directory '\(url.lastPathComponent)' could not be opened. Grant permission in the componion app."
+            "The directory '\(url.lastPathComponent)' could not be opened. Grant permission in the companion app."
         )
     }
 


### PR DESCRIPTION
Fixes #40 

The word `companion` is misspelled as `componion`.
This PR fixes it.

Thanks for the great plugin, I am using the AppCode plugin since many years now! 🍻 