### PR TITLE
Add access modifiers and init

### DIFF
--- a/MockGenerator/MockGenerator.swift
+++ b/MockGenerator/MockGenerator.swift
@@ -18,7 +18,7 @@ extension MockGenerator {
         guard !isEmpty(mockClass: mockClass) else {
             throw error("Could not find a class or protocol on \(element.name)")
         }
-        let mockLines = getMockBody(from: mockClass)
+        let mockLines = getMockBody(from: mockClass, element: element)
         guard !mockLines.isEmpty else {
             throw error("Found inherited types but there was nothing to mock")
         }
@@ -40,9 +40,9 @@ extension MockGenerator {
         return mockClass.protocols.isEmpty && mockClass.inheritedClass == nil
     }
 
-    private func getMockBody(from mockClass: MockClass) -> [String] {
+    private func getMockBody(from mockClass: MockClass, element: TypeDeclaration) -> [String] {
         let view = CallbackMockView { [templateName] model in
-            let view = MustacheView(templateName: templateName)
+            let view = MustacheView(templateName: templateName, element: element)
             view.render(model: model)
             return view.result
         }

--- a/MockGenerator/MustacheView.swift
+++ b/MockGenerator/MustacheView.swift
@@ -1,21 +1,40 @@
 import UseCases
 import GRMustache
 import Foundation
+import AST
 
 class MustacheView: NSObject, MockView {
 
     private(set) var result = ""
     private let templateName: String
+    private let element: AST.TypeDeclaration
 
-    init(templateName: String) {
+    init(templateName: String, element: AST.TypeDeclaration) {
         self.templateName = templateName
+        self.element = element
     }
 
     func render(model: MockViewModel) {
         do {
             let template = try GRMustacheTemplate(fromResource: templateName, bundle: Bundle(for: MustacheView.self))
-            result = try template.renderObject(model.toDictionary())
+            var dict = model.toDictionary().mutableCopy() as! NSMutableDictionary
+            dict["scope"] = getScope()
+            result = try template.renderObject(dict)
         } catch { } // ignored
+    }
+    
+    private func getScope() -> String? {
+        if element.hasOpenModifier {
+            return "open"
+        } else if element.hasPublicModifier {
+            return "public"
+        } else if element.hasInternalModifier {
+            return "internal"
+        } else if element.hasPrivateModifier || element.hasFilePrivateModifier {
+            return "fileprivate"
+        } else {
+            return nil
+        }
     }
 }
 
@@ -27,9 +46,6 @@ extension MockViewModel {
         dictionary["property"] = property.map { $0.toDictionary() }
         dictionary["method"] = method.map { $0.toDictionary() }
         dictionary["subscript"] = `subscript`.map { $0.toDictionary() }
-        if let scope = scope {
-            dictionary["scope"] = scope
-        }
         return dictionary
     }
 }

--- a/MockGenerator/dummy.mustache
+++ b/MockGenerator/dummy.mustache
@@ -4,6 +4,12 @@
     }
 {{/initializer}}
 
+{{#publicInitializer}}
+    {{scope}} init() {
+        fatalError("Not implemented")
+    }
+{{/publicInitializer}}
+
 {{#property}}
 
 

--- a/MockGenerator/dummy.mustache
+++ b/MockGenerator/dummy.mustache
@@ -1,5 +1,5 @@
 {{#initializer}}
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
     {{{initializerCall}}}
     }
 {{/initializer}}
@@ -9,7 +9,7 @@
 
     {{#hasSetter}}
 
-        {{{declarationText}}} {
+        {{scope}} {{{declarationText}}} {
         set {
         }
         get {
@@ -21,7 +21,7 @@
     {{/hasSetter}}
     {{^hasSetter}}
 
-        {{{declarationText}}} {
+        {{scope}} {{{declarationText}}} {
         {{#defaultValue}}return {{{defaultValue}}}{{/defaultValue}}
         {{^defaultValue}}fatalError("Dummy implementation"){{/defaultValue}}
         }
@@ -32,7 +32,7 @@
 
 {{#subscript}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     {{#hasSetter}}
         set {
@@ -51,7 +51,7 @@
 
 {{#method}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     {{#resultType}}
         {{#defaultValue}}return {{{defaultValue}}}{{/defaultValue}}

--- a/MockGenerator/partial.mustache
+++ b/MockGenerator/partial.mustache
@@ -4,6 +4,12 @@
     }
 {{/initializer}}
 
+{{#publicInitializer}}
+    {{scope}} init() {
+        fatalError("Not implemented")
+    }
+{{/publicInitializer}}
+
 {{#property}}
 
     {{#hasSetter}}

--- a/MockGenerator/partial.mustache
+++ b/MockGenerator/partial.mustache
@@ -1,5 +1,5 @@
 {{#initializer}}
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
     {{{initializerCall}}}
     }
 {{/initializer}}
@@ -20,7 +20,7 @@
         {{scope}} var forwardToOriginal{{capitalizedUniqueName}} = false
     {{/isImplemented}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     {{#hasSetter}}
         set {
@@ -85,7 +85,7 @@
         {{scope}} var forwardToOriginal{{capitalizedUniqueName}} = false
     {{/isImplemented}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     {{#hasSetter}}
         set {
@@ -167,7 +167,7 @@
         {{scope}} var forwardToOriginal{{capitalizedUniqueName}} = false
     {{/isImplemented}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     invoked{{capitalizedUniqueName}} = true
     invoked{{capitalizedUniqueName}}Count += 1

--- a/MockGenerator/spy.mustache
+++ b/MockGenerator/spy.mustache
@@ -1,5 +1,5 @@
 {{#initializer}}
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
     {{{initializerCall}}}
     }
 {{/initializer}}
@@ -16,7 +16,7 @@
     {{scope}} var invoked{{capitalizedUniqueName}}GetterCount = 0
     {{scope}} var stubbed{{capitalizedUniqueName}}: {{{iuoType}}} {{{defaultValueAssignment}}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     {{#hasSetter}}
         set {
@@ -61,7 +61,7 @@
         {{scope}} var invoked{{capitalizedUniqueName}}List = [{{{resultType.type}}}]()
     {{/hasSetter}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     {{#hasSetter}}
         set {
@@ -124,7 +124,7 @@
         {{scope}} var stubbed{{capitalizedUniqueName}}Result: {{{iuoType}}} {{{defaultValueAssignment}}}
     {{/resultType}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     invoked{{capitalizedUniqueName}} = true
     invoked{{capitalizedUniqueName}}Count += 1

--- a/MockGenerator/spy.mustache
+++ b/MockGenerator/spy.mustache
@@ -4,6 +4,12 @@
     }
 {{/initializer}}
 
+{{#publicInitializer}}
+    {{scope}} init() {
+        fatalError("Not implemented")
+    }
+{{/publicInitializer}}
+
 {{#property}}
 
     {{#hasSetter}}

--- a/MockGenerator/stub.mustache
+++ b/MockGenerator/stub.mustache
@@ -4,6 +4,12 @@
     }
 {{/initializer}}
 
+{{#publicInitializer}}
+    {{scope}} init() {
+        fatalError("Not implemented")
+    }
+{{/publicInitializer}}
+
 {{#property}}
 
     {{scope}} var stubbed{{capitalizedUniqueName}}: {{{iuoType}}} {{{defaultValueAssignment}}}

--- a/MockGenerator/stub.mustache
+++ b/MockGenerator/stub.mustache
@@ -1,5 +1,5 @@
 {{#initializer}}
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
     {{{initializerCall}}}
     }
 {{/initializer}}
@@ -8,7 +8,7 @@
 
     {{scope}} var stubbed{{capitalizedUniqueName}}: {{{iuoType}}} {{{defaultValueAssignment}}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     {{#hasSetter}}
         set {
@@ -29,7 +29,7 @@
 
     {{scope}} var stubbed{{capitalizedUniqueName}}Result: {{{resultType.iuoType}}} {{{resultType.defaultValueAssignment}}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     {{#hasSetter}}
         set {
@@ -51,7 +51,7 @@
         {{scope}} var stubbed{{capitalizedUniqueName}}Result: {{{iuoType}}} {{{defaultValueAssignment}}}
     {{/resultType}}
 
-    {{{declarationText}}} {
+    {{scope}} {{{declarationText}}} {
 
     {{#resultType}}
         return stubbed{{capitalizedUniqueName}}Result{{returnCastStatement}}


### PR DESCRIPTION
Adds access modifier of mock class to all its members. 
```
public protocol Foo {
   func bar()
}

public class FooSpy: Foo {
    public var invokedBar = false
    public var invokedBarCount = 0

    public init() {
         fatalError("Not implemented")
    }

    public func bar() {
        invokedBar = true
        invokedBarCount += 1
    }
}
```
It's useful when mocks are in separate module and saves you from adding modifiers manually. Also adds dummy init when mock is `public` or `open` and no init was generated.